### PR TITLE
Fix spawn python error for windows installed app

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -130,7 +130,7 @@ const selectPort = () => {
 const createPyProc = () => {
   let port = "" + selectPort();
   let script = path.join(__dirname, "pycalc", "api.py");
-  pyProc = require("child_process").spawn("python", [script, port]);
+  pyProc = require("child_process").spawn("python", [script, port], {shell: true});
   if (pyProc != null) {
     console.log("child process success");
   }


### PR DESCRIPTION
### Fixes:
- Closes: #160

### Changes
Addition of `shell: true` option solves the issue 

### Reference:
- Reference about the buggy code from [here](https://stackoverflow.com/questions/27688804/how-do-i-debug-error-spawn-enoent-on-node-js#:~:text=simply%20adding%20shell%3A%20true%20option%20solved%20my%20problem%3A).

### Behaviour:
- Pop-up error is no longer showing (as expected).